### PR TITLE
searchservice: enhancements to method docs

### DIFF
--- a/doc/searchservice.md
+++ b/doc/searchservice.md
@@ -53,8 +53,8 @@ the near future.
 ## Method `/docs`
 
 If the tool is launched with a file containing a stream of documents as an 
-input it is able to create an index at startup and then serving either the
-method `/search` either a new method `/docs`.
+input it is able to create an index at startup and then serve in addition 
+method `/docs`.
 
 ```sh
 $ searchservice -p 5000 -d documents.txt -id i -content c,t

--- a/doc/searchservice.md
+++ b/doc/searchservice.md
@@ -71,16 +71,29 @@ Note that:
 - *searchservice* requires a field with unique ids. This ids must be strictly
   positive integers.
 - *searchservice* with method `/docs` is giving back the documents in lines that
-  are binary identical to the ones found ont the original source.
+  are binary identical to the ones found on the original source. There are no
+  problems serving documents with a complex structures (the only limit is that 
+  nested content cannot be indexed for search).
 
-Method `/docs` just get one parameter:
+Method `/docs` by default returns all documents sorted by document id:
 
 ```sh
-$ wget -o - http://localhost:5000/docs?ids=1+45+47
+$ wget -o - http://localhost:5000/docs
 {"i"=1,"t"="Index this title please","c"="Some other content to index"}
 {"i"=45,"t"="Index this other title please","c"="...again content to index"}
 {"i"=47,"t"="Index this other title please","c"="...again content to index"}
 ```
+
+The following optional arguments can be used:
+- `ids`: a space separated list of document ids. If passed it will return 
+  only selected documents in the very same order as the passed list. 
+  Repetitions in the list are allowed and would return the same document more 
+  than once.
+- `l`: a numerical positive value to limit the documents to be returned.
+
+
+An identical method `/docs.gz` exists that works identically to `/docs` but 
+adds `gzip` compression on top of all returned bytes.
 
 
 ## Method `/app`

--- a/src/github.com/rressi/smartsearch/http_handlers.go
+++ b/src/github.com/rressi/smartsearch/http_handlers.go
@@ -6,30 +6,42 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"sort"
 	"strconv"
 	"strings"
 )
 
-// Creates an http.Handler to serve the passed collection of JSON documents.
+// Creates a http.Handler to serve the passed collection of JSON documents.
 //
 // Passed collection is a map with the document uuid as a key (integer) and
 // the raw JSON content to return as value.
 //
-// The web API exposed by the created web server expects to have the following
-// parameters:
-// ids: it is mandatory and a space separated list of document uuid.
+// The web API exposed by this handler accept the following arguments:
+// - ids: a space separated list of documents' uuids to select the documents
+//   to be returned. They are returned in the very same order ar respective
+//   uuids in this parameter.
+// - l: a positive integer to limit the number of returned document.
 //
-// The handle returns as a content one text file with one document per line
+// Notes:
+// - If argument "ids" is not passed all the documents are returned sorted by
+//   uuids.
+// - If just one document uuid passed with argument "ids" is not valid this web
+//   request fails.
+//
+// This handler returns as a content one text file with one document per line
 // encoded in JSON format (the same raw bytes of the passed collection of
 // documents passed originally).
-//
-// Returned documents are the same requested with web parameter ids, in the very
-// same order. Repeating many times the same ids just means to have the same
-// document returned more than once.
-//
-// If one document uuid is not valid the web request fails.
 func ServeDocuments(docs JsonDocuments) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+	// Obtains all ids:
+	allIds := make([]int, 0, len(docs))
+	for k := range docs {
+		allIds = append(allIds, k)
+	}
+	sort.Ints(allIds)
+
+	// Our web handler:
+	docsHandler := func(w http.ResponseWriter, r *http.Request) {
 
 		var httpError = http.StatusInternalServerError
 		var err error
@@ -50,45 +62,84 @@ func ServeDocuments(docs JsonDocuments) http.Handler {
 			return
 		}
 
-		idsValues, idsOk := values["ids"]
-		if !idsOk || len(idsValues) == 0 {
+		var limit int
+		limit, err = parseNumericalArgument("l", values)
+		if err != nil {
 			httpError = http.StatusBadRequest
-			err = errors.New("Missing parameter 'ids'")
 			return
 		}
 
-		w.WriteHeader(http.StatusOK)
-		httpError = 0 // Done!
-		for _, ids := range idsValues {
-			for _, idRaw := range strings.Split(ids, " ") {
-				var id int
-				id, err = strconv.Atoi(idRaw)
-				if err != nil {
-					err = fmt.Errorf("non numeric id: '%v'", idRaw)
-					httpError = http.StatusBadRequest
-					return
-				}
+		var selectedIds []int
+		idsValuesMulti, idsOk := values["ids"]
+		if idsOk {
+			// Parses all passed ids and checks their validity:
+		parseLoop:
+			for _, idsValues := range idsValuesMulti {
+				for _, idRaw := range strings.Split(idsValues, " ") {
+					if limit >= 0 && len(selectedIds) >= limit {
+						break parseLoop
+					}
 
-				var rawDocument []byte
-				rawDocument, idsOk = docs[id]
-				if !idsOk {
-					httpError = http.StatusNotFound
-					err = fmt.Errorf("invalid documente id: %v", id)
-					return
-				}
+					var id int
+					id, err = strconv.Atoi(idRaw)
+					if err != nil {
+						err = fmt.Errorf("non numeric id: '%v'", idRaw)
+						httpError = http.StatusBadRequest
+						return
+					}
 
-				_, err = w.Write(rawDocument)
-				if err != nil {
-					return
-				}
+					_, docOk := docs[id]
+					if !docOk {
+						err = fmt.Errorf("invalid document id: %v", id)
+						httpError = http.StatusNotFound
+						return
+					}
 
-				_, err = w.Write([]byte{'\n'})
-				if err != nil {
-					return
+					selectedIds = append(selectedIds, id)
 				}
 			}
+			if limit != 0 && len(selectedIds) == 0 {
+				err = errors.New("No document ids have been passed")
+				httpError = http.StatusBadRequest
+				return
+			}
+		} else {
+			selectedIds = allIds
+			if limit >= 0 && len(selectedIds) > limit {
+				selectedIds = selectedIds[:limit]
+			}
 		}
-	})
+
+		w.WriteHeader(http.StatusOK)
+		httpError = 0
+		// NOTE: it is no more possible to return an error to the client.
+
+		var count int
+		// Writes back all the documents...
+		for _, id := range selectedIds {
+			if limit >= 0 && count > limit {
+				break
+			}
+
+			rawDocument, idsOk := docs[id]
+			if !idsOk {
+				err = fmt.Errorf("invalid documente id: %v", id)
+				return
+			}
+
+			_, err = w.Write(rawDocument)
+			if err != nil {
+				return
+			}
+
+			_, err = w.Write([]byte{'\n'})
+			if err != nil {
+				return
+			}
+		}
+	}
+
+	return http.HandlerFunc(docsHandler)
 }
 
 // -----------------------------------------------------------------------------
@@ -128,20 +179,10 @@ func ServeSearch(index Index) http.HandlerFunc {
 		}
 
 		var limit int
-		limitValues, limitOk := values["l"]
-		if !limitOk {
-			limit = -1
-		} else if len(limitValues) != 1 {
+		limit, err = parseNumericalArgument("l", values)
+		if err != nil {
 			httpError = http.StatusBadRequest
-			err = errors.New("Parameter 'limit' passed more than once")
 			return
-		} else {
-			limit, err = strconv.Atoi(limitValues[0])
-			if err != nil {
-				err = fmt.Errorf("invalid value for parameter 'limit': %v",
-					limitValues[0])
-				return
-			}
 		}
 
 		var postings []int
@@ -171,6 +212,7 @@ func ServeSearch(index Index) http.HandlerFunc {
 
 // -----------------------------------------------------------------------------
 
+// Just servers passed bytes via http.
 func ServeRawBytes(raw []byte) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 
@@ -193,4 +235,29 @@ func ServeRawBytes(raw []byte) http.HandlerFunc {
 
 		httpError = 0 // Done!
 	}
+}
+
+// Parses an argument of type integer value from an HTTP request.
+func parseNumericalArgument(name string, values map[string][]string) (
+	limit int, err error) {
+
+	var limit_ int
+	limitValues, limitOk := values[name]
+	if !limitOk {
+		limit_ = -1
+	} else if len(limitValues) != 1 {
+		err = errors.New("Parameter 'limit' passed more than once")
+		return
+	} else {
+		limit_, err = strconv.Atoi(limitValues[0])
+		if err != nil {
+			err = fmt.Errorf("invalid value for parameter 'limit': %v",
+				limitValues[0])
+			return
+		}
+	}
+
+	// Success!
+	limit = limit_
+	return
 }

--- a/src/searchservice.go
+++ b/src/searchservice.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"github.com/NYTimes/gziphandler"
 	"github.com/rressi/smartsearch"
 	"io"
 	"net/http"
@@ -210,7 +211,9 @@ func RunSearchService(ctx AppContext, httpHostName string, httpPort uint) (
 	http.HandleFunc("/search", smartsearch.ServeSearch(ctx.index))
 	http.HandleFunc("/rawIndex", smartsearch.ServeRawBytes(ctx.rawIndex))
 	if ctx.docs != nil {
-		http.Handle("/docs", smartsearch.ServeDocuments(ctx.docs))
+		docsHandler := smartsearch.ServeDocuments(ctx.docs)
+		http.Handle("/docs", docsHandler)
+		http.Handle("/docs.gz", gziphandler.GzipHandler(docsHandler))
 	}
 	if ctx.staticAppFolder != "" {
 		http.Handle("/app/", http.StripPrefix("/app/",


### PR DESCRIPTION
# Description

As requested by #1, we are adding the following features to method `/docs`:
- compression is now explicit with the addition of complementary method `/docs.gz`.
- it is possible to fetch all the documents by omitting parameter `ids`.
- it is possible to limit the total number of documents by passing new parameter `l`.
- `test_functional_docs` is testing also the new features and now is much faster because works with many threads in parallel.
